### PR TITLE
Add validation test utility.

### DIFF
--- a/packaging/rpm/cvmfs-x509-helper.spec
+++ b/packaging/rpm/cvmfs-x509-helper.spec
@@ -65,6 +65,7 @@ rm -rf $RPM_BUILD_ROOT
 %files
 %defattr(-,root,root)
 /usr/libexec/cvmfs/authz/cvmfs_x509_helper
+/usr/libexec/cvmfs/authz/cvmfs_x509_validator
 %doc COPYING AUTHORS README ChangeLog
 
 %changelog

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,12 +9,23 @@ set (CVMFS_X509_HELPER_SOURCES
   x509_helper_req.cc x509_helper_req.h
   x509_helper_voms.cc x509_helper_voms.h)
 
+set (CVMFS_X509_VALIDATOR_SOURCES
+  x509_validator.cc
+  x509_helper_globus.cc x509_helper_globus.h
+  x509_helper_log.cc x509_helper_log.h
+  x509_helper_dynlib.cc x509_helper_dynlib.h
+  x509_helper_voms.cc x509_helper_voms.h)
+
 add_executable (cvmfs_x509_helper ${CVMFS_X509_HELPER_SOURCES})
+add_executable (cvmfs_x509_validator ${CVMFS_X509_VALIDATOR_SOURCES})
 add_dependencies (cvmfs_x509_helper libvjson)
 target_link_libraries (cvmfs_x509_helper vjson ${OPENSSL_LIBRARIES} dl)
+target_link_libraries (cvmfs_x509_validator dl)
 
 install (
-  TARGETS      cvmfs_x509_helper
+  TARGETS      cvmfs_x509_helper cvmfs_x509_validator
   RUNTIME
   DESTINATION    libexec/cvmfs/authz
 )
+
+

--- a/src/x509_validator.cc
+++ b/src/x509_validator.cc
@@ -1,0 +1,13 @@
+/**
+ * This file is part of the CernVM File System.
+ */
+#define __STDC_FORMAT_MACROS
+
+#include "x509_helper_globus.h"
+#include "x509_helper_voms.h"
+
+int main() {
+
+  return !GlobusLib::GetInstance()->IsValid() || !VomsLib::GetInstance()->IsValid();
+
+}


### PR DESCRIPTION
OSG would like to be able to test if the appropriate Globus libaries
are available on the worker node; if not, we want to put the ones
we ship in a CVMFS repository into the environment of the auth
helper at configuration time.

This validation utility will return non-zero if the Globus/VOMS
install is broken.